### PR TITLE
Securely email client login on budget close

### DIFF
--- a/src/app/api/orcamentos/[id]/status/route.ts
+++ b/src/app/api/orcamentos/[id]/status/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db";
 import { auth } from "@/../auth";
 import { z } from "zod";
 import bcrypt from "bcryptjs"; // For password hashing
+import { sendEmail } from "@/lib/email";
 
 // Define the OrcamentoStatus enum values from your schema.prisma
 enum OrcamentoStatus {
@@ -130,9 +131,17 @@ export async function PATCH(
                 },
               },
             });
-            console.log(`Novo usuário criado para cliente ${cliente.id} com ID: ${newUser.id}. Senha (antes do hash): ${rawPassword}`);
-            // TODO: Implement email sending with credentials (rawPassword) here if required
-            // For security, do not log rawPassword in production
+            console.log(`Novo usuário criado para cliente ${cliente.id} com ID: ${newUser.id}.`);
+
+            try {
+              await sendEmail(
+                newUser.email,
+                "Acesso ao Portal do Cliente",
+                `<p>Olá ${newUser.name},</p><p>Seu acesso ao portal foi criado.</p><p><strong>Usuário:</strong> ${newUser.email}</p><p><strong>Senha:</strong> ${rawPassword}</p>`
+              );
+            } catch (emailError) {
+              console.error(`Falha ao enviar e-mail para ${newUser.email}:`, emailError);
+            }
 
           } catch (userCreationError: any) {
             console.error(`Erro ao criar usuário para cliente ${cliente.id}:`, userCreationError);

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,22 @@
+import nodemailer from "nodemailer";
+
+export async function sendEmail(to: string, subject: string, html: string) {
+  const transporter = nodemailer.createTransport({
+    host: process.env.EMAIL_SERVER_HOST || "smtp.gmail.com",
+    port: Number(process.env.EMAIL_SERVER_PORT) || 465,
+    secure: true,
+    auth: {
+      user: process.env.EMAIL_SERVER_USER || "",
+      pass: process.env.EMAIL_SERVER_PASSWORD || "",
+    },
+  });
+
+  const from = process.env.EMAIL_FROM || process.env.EMAIL_SERVER_USER || "";
+
+  await transporter.sendMail({
+    from,
+    to,
+    subject,
+    html,
+  });
+}


### PR DESCRIPTION
## Summary
- add email helper for nodemailer
- remove logging of client password and send credentials by email when creating the user

## Testing
- `npm run lint` *(fails: next not found)*