### PR TITLE
Add Visita form state and missing components

### DIFF
--- a/src/components/visita/VisitaFormWrapper.tsx
+++ b/src/components/visita/VisitaFormWrapper.tsx
@@ -2,12 +2,12 @@
 
 import React from "react";
 import { useEffect, useState } from "react";
-import { StepEndereco } from "./steps/StepEndereco";
-import { StepAmbiente } from "./steps/StepAmbiente";
+import { StepEndereco } from "./step/StepEndereco";
+import { StepAmbiente } from "./step/StepAmbiente";
 import { useVisitaFormState } from "./useVisitaFormState";
-import { StepCamposProduto } from "./steps/StepCamposProduto";
-import { StepProduto } from "./steps/StepProduto";
-import { StepFoto } from "./steps/StepFoto";
+import { StepCamposProduto } from "./step/StepCamposProduto";
+import { StepProduto } from "./step/StepProduto";
+import { StepFoto } from "./step/StepFoto";
 import { VisitaResumo } from "./VisitaResumo";
 
 export function VisitaFormWrapper({ visita }: { visita: any }) {
@@ -27,7 +27,7 @@ export function VisitaFormWrapper({ visita }: { visita: any }) {
     <StepEndereco visita={visita} onNext={next} />,
     <StepAmbiente onBack={back} onNext={next} />,
     <StepProduto onBack={back} onNext={next} />,
-    <StepCamposProduto produto={{ tipo: "cortina" }} onConfirm={next} />,
+    <StepCamposProduto onConfirm={next} />,
     <StepFoto onNext={next} />,
     <VisitaResumo />
   ];

--- a/src/components/visita/VisitaResumo.tsx
+++ b/src/components/visita/VisitaResumo.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useVisitaFormState } from "./useVisitaFormState";
+
+export function VisitaResumo() {
+  const { ambientes } = useVisitaFormState();
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold text-primary">Resumo da Visita</h2>
+      {ambientes.map((amb, i) => (
+        <div key={i} className="border rounded p-2">
+          <p className="font-medium">{amb.nome}</p>
+          {amb.produtos.length > 0 && (
+            <ul className="list-disc pl-4 text-sm">
+              {amb.produtos.map((p, idx) => (
+                <li key={idx}>{p.tipo}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/visita/step/StepAmbiente.tsx
+++ b/src/components/visita/step/StepAmbiente.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useVisitaFormState } from "../useVisitaFormState";
 
 const ambientesPadrao = [
   "Sala",
@@ -21,6 +22,7 @@ export function StepAmbiente({
 }) {
   const [ambienteSelecionado, setAmbienteSelecionado] = useState("");
   const [observacoes, setObservacoes] = useState("");
+  const { addAmbiente } = useVisitaFormState();
 
   const podeAvancar = ambienteSelecionado !== "";
 
@@ -64,7 +66,10 @@ export function StepAmbiente({
         </button>
 
         <button
-          onClick={onNext}
+          onClick={() => {
+            addAmbiente({ nome: ambienteSelecionado, observacoes });
+            onNext();
+          }}
           disabled={!podeAvancar}
           className="bg-primary text-white px-4 py-2 rounded hover:bg-primary/90"
         >

--- a/src/components/visita/step/StepFoto.tsx
+++ b/src/components/visita/step/StepFoto.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+
+export function StepFoto({ onNext }: { onNext: () => void }) {
+  const [foto, setFoto] = useState<File | null>(null);
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Fotos do Local</h2>
+      <input
+        type="file"
+        accept="image/*"
+        onChange={(e) => setFoto(e.target.files?.[0] || null)}
+      />
+      <button
+        className="bg-primary text-white px-4 py-2 rounded"
+        onClick={onNext}
+        disabled={!foto}
+      >
+        Próximo
+      </button>
+    </div>
+  );
+}

--- a/src/components/visita/useVisitaFormState.ts
+++ b/src/components/visita/useVisitaFormState.ts
@@ -1,0 +1,48 @@
+import { create } from "zustand";
+
+interface Produto {
+  tipo: string;
+  [key: string]: any;
+}
+
+interface Ambiente {
+  nome: string;
+  observacoes?: string;
+  produtos: Produto[];
+}
+
+interface VisitaFormState {
+  visitaId: string | null;
+  clienteId: string | null;
+  ambientes: Ambiente[];
+  setVisitaInfo: (visitaId: string | null, clienteId: string | null) => void;
+  addAmbiente: (ambiente: Omit<Ambiente, "produtos">) => void;
+  addProdutoToAmbiente: (index: number, produto: Produto) => void;
+  updateAmbiente: (index: number, ambiente: Ambiente) => void;
+  reset: () => void;
+}
+
+export const useVisitaFormState = create<VisitaFormState>((set) => ({
+  visitaId: null,
+  clienteId: null,
+  ambientes: [],
+  setVisitaInfo: (visitaId, clienteId) => set({ visitaId, clienteId }),
+  addAmbiente: (ambiente) =>
+    set((state) => ({ ambientes: [...state.ambientes, { ...ambiente, produtos: [] }] })),
+  addProdutoToAmbiente: (index, produto) =>
+    set((state) => {
+      const ambientes = [...state.ambientes];
+      const alvo = ambientes[index];
+      if (!alvo) return { ambientes };
+      alvo.produtos.push(produto);
+      return { ambientes };
+    }),
+  updateAmbiente: (index, ambiente) =>
+    set((state) => {
+      const ambientes = [...state.ambientes];
+      ambientes[index] = ambiente;
+      return { ambientes };
+    }),
+  reset: () => set({ visitaId: null, clienteId: null, ambientes: [] }),
+}));
+


### PR DESCRIPTION
## Summary
- implement `useVisitaFormState` store for visita steps
- hook up StepAmbiente to store
- add StepFoto step and VisitaResumo summary
- adjust VisitaFormWrapper imports and cleanup

## Testing
- `npm run lint` *(fails: next not found)*