### PR TITLE
Fix deprecated config export

### DIFF
--- a/src/app/api/admin/sefaz-config/route.ts
+++ b/src/app/api/admin/sefaz-config/route.ts
@@ -67,9 +67,9 @@ const configSchemaPOST = z.object({
   ),
 });
 
-export const config = {
+export const routeSegmentConfig = {
   api: {
-    bodyParser: false, 
+    bodyParser: false,
   },
 };
 


### PR DESCRIPTION
## Summary
- update deprecated `config` export to `routeSegmentConfig`

## Testing
- `npm run lint` *(fails: next not found)*