### PR TITLE
Fix fonts import errors

### DIFF
--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,6 +1,6 @@
 // app/(protected)/layout.tsx
 import { ReactNode } from "react";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter } from "next/font/google";
 import "@/app/globals.css";
 
 // 1) importe seu layout de componentes
@@ -10,13 +10,9 @@ import type { AuthPayload } from "@/lib/types";
 import { getUserFromToken } from "@/lib/auth";
 import { UserProvider } from "@/store/UserProvider";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
   subsets: ["latin"],
-});
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  variable: "--font-inter",
 });
 
 export default async function RootLayout({

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,6 +1,4 @@
 import {
-  Geist,
-  Geist_Mono,
   Instrument_Sans,
   Inter,
   Mulish,
@@ -9,12 +7,12 @@ import {
 
 import { cn } from "@/lib/utils"
 
-const fontSans = Geist({
+const fontSans = Inter({
   subsets: ["latin"],
   variable: "--font-sans",
 })
 
-const fontMono = Geist_Mono({
+const fontMono = Noto_Sans_Mono({
   subsets: ["latin"],
   variable: "--font-mono",
 })


### PR DESCRIPTION
## Summary
- replace unsupported Geist font usage with Inter
- adjust font definitions to avoid unknown fonts

## Testing
- `npm run lint` *(fails: next not found)*